### PR TITLE
Basic instructions about third-party cookies

### DIFF
--- a/app/views/dce_lti/sessions/invalid.html.erb
+++ b/app/views/dce_lti/sessions/invalid.html.erb
@@ -1,0 +1,19 @@
+<h1>Invalid Session</h1>
+<p>Oops. We couldn't log you in to this application.</p>
+
+<p>This might be because you've disabled third party cookies, or because you're
+  using the Safari browser which disables them by default.</p>
+
+<p>Please use an alternate browser such as <a
+    href="//www.mozilla.org/en-US/firefox/new/">Firefox</a> or <a
+    href="//www.google.com/chrome">Google Chrome</a> while we implement a
+  permanent fix.</p>
+
+<h2>Enabling third-party cookies in Safari</h2>
+<ol>
+  <li>Open Safari,</li>
+  <li>In the top left corner of your screen click on "Safari",</li>
+  <li>Select "Preferences",</li>
+  <li>In the "Preferences" window select the "Privacy" option,</li>
+  <li>Under "Block cookies" select "Never"</li>
+</ol>

--- a/spec/features/session_failed_customizations_spec.rb
+++ b/spec/features/session_failed_customizations_spec.rb
@@ -1,0 +1,7 @@
+feature 'LTI Session negotiation fails possibly due to third party cookies' do
+  scenario 'a relevant message should be displayed' do
+    visit '/'
+
+    expect(page).to have_content /enabling third-party cookies/i
+  end
+end


### PR DESCRIPTION
Third-party cookies are currently required to use this application and are
disabled by default in safari. Give basic instructions on how to enable them.

https://trello.com/c/mjRRD0LP